### PR TITLE
Broyden method

### DIFF
--- a/R/05_01_validate_model_input.R
+++ b/R/05_01_validate_model_input.R
@@ -57,7 +57,7 @@ Please complete exogenous variables and initial values
   # 3 Check if provided equations do not contain invalid characters
   all_equations <- model$equations$equation
   for (i in all_equations) {
-    if (stringr::str_detect(i, "[\u00A7\u00A3@#\\${};:'\\\\~?]")) {
+    if (stringr::str_detect(i, "[\u00A7\u00A3@#\\;:'\\\\~?]")) {
       warning("Possible invalid character(s) in equation. Please check: ", i, "")
     }
   }
@@ -109,7 +109,7 @@ Please check: ", variables_user[i], "
     stringr::str_replace_all("[(]", "")
   # equations divided into lhs and rhs
   equations_sep <- tibble::tibble(equations) %>%
-    tidyr::separate(.data$equations, c("lhs", "rhs"), "=") %>%
+    tidyr::separate(.data$equations, c("lhs", "rhs"), "=", extra = "merge") %>% # allows <= in equations
     dplyr::mutate(
       lhs = stringr::str_squish(lhs),
       rhs = stringr::str_squish(rhs)
@@ -126,6 +126,7 @@ Please check: ", variables_user[i], "
     stringr::str_split(" ", simplify = T) %>%
     vecsets::vsetdiff(functions) %>%
     unique()
+  variables_eqs <- grep("^(if|else|\\{)", variables_eqs, invert = TRUE, value = TRUE) # remove if, else, {
   variables_eqs <- variables_eqs[suppressWarnings(is.na(as.numeric(variables_eqs)))]
   # variables not-defined by the user but present in equations
   variables_not_user <- vecsets::vsetdiff(variables_eqs, variables_user)

--- a/R/05_01_validate_model_input.R
+++ b/R/05_01_validate_model_input.R
@@ -177,7 +177,7 @@ Please remove one of the equations
   # 10. check if there are exogenous variables not defined by the user
   v <- vecsets::vsetdiff(variables_not_user, variables_endo)
   if (length(v) != 0) {
-    stop(paste0("These exogenous variables are not defined
+    warning(paste0("These exogenous variables are not defined
 Please add them to the model: ", paste0(v, collapse = ", "), "
 "))
   }

--- a/R/05_01_validate_model_input.R
+++ b/R/05_01_validate_model_input.R
@@ -58,7 +58,7 @@ Please complete exogenous variables and initial values
   all_equations <- model$equations$equation
   for (i in all_equations) {
     if (stringr::str_detect(i, "[\u00A7\u00A3@#\\${};:'\\\\~?]")) {
-      stop("Invalid character(s) in equation. Please check: ", i, "")
+      warning("Possible invalid character(s) in equation. Please check: ", i, "")
     }
   }
 

--- a/R/07_03_run_newton.R
+++ b/R/07_03_run_newton.R
@@ -107,8 +107,17 @@ Please check if equations are correctly specified or change initial values")
           exs <- exs_nl[[.b]]
 
           #x <- rootSolve::multiroot(block_foo, xstart, max_iter, ctol = tol)
-          x <- nleqslv::nleqslv(x = xstart, fn = block_foo, jac = NULL, method = method, 
-                                global = global, control = list(maxit = max_iter, xtol = tol, ...))
+          tryCatch(
+            {x <- nleqslv::nleqslv(x = xstart, fn = block_foo, jac = NULL, method = method, 
+                                   global = global, control = list(maxit = max_iter, xtol = tol, allowSingular = TRUE))
+            },
+            error = function(e) {
+              pattern <- "(?<=index=)\\d+"
+              extracted_number <- as.numeric(stringr::str_extract(conditionMessage(e), pattern))
+              eq <- as.character(exs[[extracted_number]])[2]
+              cat(glue::glue("The solver did not converge.\n During computation NaN or Inf was obtained in equation:\n {eq}\n Please check if equations are correctly specified or change initial values"))
+            }
+          )
 
           # for (.v in seq_along(x$root)) {
           #   m[.i, idvar_[[.v]]] <- x$root[.v]

--- a/R/07_03_run_newton.R
+++ b/R/07_03_run_newton.R
@@ -25,6 +25,7 @@ prep_broyden <- function(.block) {
 # ' @param periods total number of rows (periods) in the model
 # ' @param max_iter maximum number of iterations allowed per block per period
 # ' @param tol tolerance accepted to determine convergence
+# ' @param 
 # ' @param ... additional arguments passed to \code{nleqslv()} control parameters
 # '
 # ' @details This function implements the Newton-Raphson and Broyden methods to solve the cyclical
@@ -32,7 +33,7 @@ prep_broyden <- function(.block) {
 # '
 # ' @return simulated scenario matrix
 
-run_newton <- function(m,
+run_newton_broyden <- function(m,
                        calls,
                        method,
                        periods,

--- a/R/07_03_run_newton.R
+++ b/R/07_03_run_newton.R
@@ -1,10 +1,10 @@
-# ' Prep equations for Newton solvers
-# '
-# ' @author João Macalós
-# '
-# ' @param .block blocks of equations
-# '
-# ' @return blocks
+#' Prep equations for Newton solvers
+#'
+#' @author João Macalós
+#'
+#' @param .block blocks of equations
+#'
+#' @return blocks
 
 prep_broyden <- function(.block) {
   for (.i in seq_len(vctrs::vec_size(.block))) {
@@ -13,25 +13,25 @@ prep_broyden <- function(.block) {
   return(.block)
 }
 
-# ' Newton Raphson and Broyden solver implemented with \code{nleqslv::nleqslv()}
-# '
-# ' @author João Macalós
-# ' @editor Iwo Augustyński (2025) - switched from rootSolve::multiroot to nleqslv::nleqslv
-# ' @importFrom nleqslv nleqslv
-# '
-# ' @param m the initialized matrix obtained with code{prepare()} or \code{prepare_scenario_matrix()}
-# ' @param calls prepared equations with \code{prepare()}
-# ' @param method either "Newton" or "Broyden"
-# ' @param periods total number of rows (periods) in the model
-# ' @param max_iter maximum number of iterations allowed per block per period
-# ' @param tol tolerance accepted to determine convergence
-# ' @param 
-# ' @param ... additional arguments passed to \code{nleqslv()} control parameters
-# '
-# ' @details This function implements the Newton-Raphson and Broyden methods to solve the cyclical
-# ' blocks of equations. It relies on the \code{nleqslv()} function from \code{nleqslv}.
-# '
-# ' @return simulated scenario matrix
+#' Newton Raphson and Broyden solver implemented with \code{nleqslv::nleqslv()}
+#'
+#' @author João Macalós
+#' @editor Iwo Augustyński (2025) - switched from rootSolve::multiroot to nleqslv::nleqslv
+#' @importFrom nleqslv nleqslv
+#'
+#' @param m the initialized matrix obtained with code{prepare()} or \code{prepare_scenario_matrix()}
+#' @param calls prepared equations with \code{prepare()}
+#' @param method either "Newton" or "Broyden"
+#' @param periods total number of rows (periods) in the model
+#' @param max_iter maximum number of iterations allowed per block per period
+#' @param tol tolerance accepted to determine convergence
+#' @param global character, global strategy for nleqslv, see \code{nleqslv::nleqslv()} documentation, defaults to "dbldog"
+#' @param ... additional arguments passed to \code{nleqslv()} control parameters, see \code{nleqslv::nleqslv()} documentation
+#'
+#' @details This function implements the Newton-Raphson and Broyden methods to solve the cyclical
+#' blocks of equations. It relies on the \code{nleqslv()} function from \code{nleqslv}.
+#'
+#' @return simulated scenario matrix
 
 run_newton_broyden <- function(m,
                        calls,

--- a/R/07_03_run_newton.R
+++ b/R/07_03_run_newton.R
@@ -13,26 +13,32 @@ prep_broyden <- function(.block) {
   return(.block)
 }
 
-# ' Newton Raphson solver implemented with \code{rootSolve::multiroot()}
+# ' Newton Raphson and Broyden solver implemented with \code{nleqslv::nleqslv()}
 # '
 # ' @author João Macalós
+# ' @editor Iwo Augustyński (2025) - switched from rootSolve::multiroot to nleqslv::nleqslv
+# ' @importFrom nleqslv nleqslv
 # '
 # ' @param m the initialized matrix obtained with code{prepare()} or \code{prepare_scenario_matrix()}
 # ' @param calls prepared equations with \code{prepare()}
+# ' @param method either "Newton" or "Broyden"
 # ' @param periods total number of rows (periods) in the model
 # ' @param max_iter maximum number of iterations allowed per block per period
 # ' @param tol tolerance accepted to determine convergence
+# ' @param ... additional arguments passed to \code{nleqslv()} control parameters
 # '
-# ' @details This function implements the Newton-Raphson method to solve the cyclical
-# ' blocks of equations. It relies on the \code{multiroot()} function from \code{rootSolve}.
+# ' @details This function implements the Newton-Raphson and Broyden methods to solve the cyclical
+# ' blocks of equations. It relies on the \code{nleqslv()} function from \code{nleqslv}.
 # '
 # ' @return simulated scenario matrix
 
 run_newton <- function(m,
                        calls,
+                       method,
                        periods,
                        max_iter,
                        tol,
+                       global = "dbldog",
                        ...) {
   blocks <- unique(sort(calls$block))
 
@@ -81,7 +87,7 @@ run_newton <- function(m,
         m[.i, idvar_] <- eval(exs_l[[.b]][[1]])
 
         if (is.na(m[.i, idvar_]) | !is.finite(m[.i, idvar_])) {
-          stop("Newton algorithm failed
+          stop("Algorithm failed
 During computation NaN or Inf was obtained in ", idvar_, " equation
 Please check if equations are correctly specified or change initial values")
         }
@@ -91,7 +97,7 @@ Please check if equations are correctly specified or change initial values")
           m[.i, idvar_] <- eval(exs_l[[.b]][[1]])
 
           if (is.na(m[.i, idvar_]) | !is.finite(m[.i, idvar_])) {
-            stop("Newton algorithm failed
+            stop("Algorithm failed
 During computation NaN or Inf was obtained in ", idvar_, " equation
 Please check if equations are correctly specified or change initial values")
           }
@@ -99,11 +105,17 @@ Please check if equations are correctly specified or change initial values")
           xstart <- m[.i - 1, idvar_]
           exs <- exs_nl[[.b]]
 
-          x <- rootSolve::multiroot(block_foo, xstart, max_iter, ctol = tol)
+          #x <- rootSolve::multiroot(block_foo, xstart, max_iter, ctol = tol)
+          x <- nleqslv::nleqslv(x = xstart, fn = block_foo, jac = NULL, method = method, 
+                                global = global, control = list(maxit = max_iter, xtol = tol, ...))
 
-          for (.v in seq_along(x$root)) {
-            m[.i, idvar_[[.v]]] <- x$root[.v]
-            # m[.i, block_names[[.b]]] <- x$iter
+          # for (.v in seq_along(x$root)) {
+          #   m[.i, idvar_[[.v]]] <- x$root[.v]
+          #   # m[.i, block_names[[.b]]] <- x$iter
+          # }
+          for (.v in seq_along(x$x)) {
+            m[.i, idvar_[[.v]]] <- x$x[.v]
+
           }
         }
       }

--- a/R/07_simulate_scenario.R
+++ b/R/07_simulate_scenario.R
@@ -46,6 +46,8 @@ d <- function(x) {
 #' @param tol numeric tolerance accepted to determine convergence, defaults to 1e-05
 #' @param hidden_tol numeric error tolerance to accept the equality of hidden equations, defaults to 0.1.
 #' @param method string name of method used to find solution chosen from: 'Gauss', 'Newton', 'Broyden' defaults to 'Gauss'
+#' @param global character, global strategy for nleqslv, see \code{nleqslv::nleqslv()} documentation, defaults to "dbldog"
+#' @param ... additional arguments passed to \code{nleqslv()} control parameters, see \code{nleqslv::nleqslv()} documentation
 #' @param verbose logical to tell if additional model verbose should be displayed
 #'
 #' @return updated model containing simulated scenario(s)
@@ -59,6 +61,8 @@ simulate_scenario <- function(model,
                               max_iter = 350,
                               tol = 1e-05,
                               hidden_tol = 0.1,
+                              global = "dbldog",
+                              ...,
                               verbose = FALSE) {
   # argument check
   # type
@@ -74,6 +78,7 @@ simulate_scenario <- function(model,
   checkmate::assert_number(hidden_tol, lower = 0)
   checkmate::assert_number(tol, lower = 0)
   checkmate::assert_string(method)
+  checkmate::assert_string(global)
   checkmate::assert_logical(verbose)
   # conditions
   if (!(method %in% c("Gauss", "Newton", "Broyden"))) {

--- a/R/07_simulate_scenario.R
+++ b/R/07_simulate_scenario.R
@@ -45,7 +45,7 @@ d <- function(x) {
 #' @param start_date character date to begin the simulation in the format "yyyy-mm-dd"
 #' @param tol numeric tolerance accepted to determine convergence, defaults to 1e-05
 #' @param hidden_tol numeric error tolerance to accept the equality of hidden equations, defaults to 0.1.
-#' @param method string name of method used to find solution chosen from: 'Gauss', 'Newton', defaults to 'Gauss'
+#' @param method string name of method used to find solution chosen from: 'Gauss', 'Newton', 'Broyden' defaults to 'Gauss'
 #' @param verbose logical to tell if additional model verbose should be displayed
 #'
 #' @return updated model containing simulated scenario(s)
@@ -181,7 +181,7 @@ simulate_scenario <- function(model,
     if (method == "Gauss") {
       m <- run_gauss_seidel(m, calls, periods, max_iter, tol, verbose)
     } else if (method %in% c("Newton", "Broyden")) {
-      m <- run_newton(m, calls, method, periods, max_iter, tol)
+      m <- run_newton_broyden(m, calls, method, periods, max_iter, tol, ...)
     }
 
     # Check if hidden is fulfilled

--- a/R/07_simulate_scenario.R
+++ b/R/07_simulate_scenario.R
@@ -76,10 +76,10 @@ simulate_scenario <- function(model,
   checkmate::assert_string(method)
   checkmate::assert_logical(verbose)
   # conditions
-  if (!(method %in% c("Gauss", "Newton"))) {
+  if (!(method %in% c("Gauss", "Newton", "Broyden"))) {
     stop(
       "There is no method named ", method,
-      "Please choose from: Gauss, Newton"
+      "Please choose from: Gauss, Newton, Broyden"
     )
   }
 
@@ -180,8 +180,8 @@ simulate_scenario <- function(model,
 
     if (method == "Gauss") {
       m <- run_gauss_seidel(m, calls, periods, max_iter, tol, verbose)
-    } else if (method == "Newton") {
-      m <- run_newton(m, calls, periods, max_iter, tol)
+    } else if (method %in% c("Newton", "Broyden")) {
+      m <- run_newton(m, calls, method, periods, max_iter, tol)
     }
 
     # Check if hidden is fulfilled

--- a/vignettes/Model_SIM.Rmd
+++ b/vignettes/Model_SIM.Rmd
@@ -78,7 +78,7 @@ Now, you can simulate the model (in this example, we calculate the baseline scen
 # Simulate model
 model_sim <- simulate_scenario(model_sim,
   scenario = "baseline", max_iter = 350, periods = 100,
-  hidden_tol = 0.1, tol = 1e-05, method = "Newton"
+  hidden_tol = 0.1, tol = 1e-05, method = "Broyden"
 )
 ```
 


### PR DESCRIPTION
I extended the run_newton function with the Broyden method. I also changed the function's name to run_newton_broyden to reflect this update. Additionally, I replaced the rootSolve::multiroom function with the leqslv::nleqslv, which is faster and allows use of the Broyden method.
I updated the function's arguments accordingly, as well as the simulate_scenario function.